### PR TITLE
Update to Java 21 and refresh dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ group = 'com.mycompany'
 version = '1.0-SNAPSHOT'
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 application {
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.knowm.xchart:xchart:3.5.2'
+    implementation 'org.knowm.xchart:xchart:3.8.8'
 }
 
 shadowJar {

--- a/src/main/java/JavaSystemMonitor/GUI/CPU_Usage.java
+++ b/src/main/java/JavaSystemMonitor/GUI/CPU_Usage.java
@@ -38,7 +38,7 @@ public class CPU_Usage extends javax.swing.JPanel
     {
         dial = new DialChart(width, height);
 
-        dial.addSeries(CPU_USAGE_TITLE, 0);
+        dial.addSeries(CPU_USAGE_TITLE, 0, CPU_USAGE_TITLE);
 
         setLayout(new BorderLayout());
 
@@ -56,7 +56,7 @@ public class CPU_Usage extends javax.swing.JPanel
         final double CPU_Load = Math.min(1.0, Math.max(0.0, mbean.getSystemCpuLoad()));
 
         dial.removeSeries(CPU_USAGE_TITLE);
-        dial.addSeries(CPU_USAGE_TITLE, CPU_Load);
+        dial.addSeries(CPU_USAGE_TITLE, CPU_Load, CPU_USAGE_TITLE);
 
         repaint();
     }

--- a/src/main/java/JavaSystemMonitor/GUI/MemoryUsage.java
+++ b/src/main/java/JavaSystemMonitor/GUI/MemoryUsage.java
@@ -47,7 +47,7 @@ public class MemoryUsage extends javax.swing.JPanel
 
         memoryPieChart = new PieChart(width, height);
 
-        memoryPieChart.getStyler().setAnnotationType(PieStyler.AnnotationType.Percentage);
+        memoryPieChart.getStyler().setLabelType(PieStyler.LabelType.Percentage);
 
         final Color[] colors =
         {


### PR DESCRIPTION
## Summary
- Target Java 21 for compilation
- Upgrade XChart dependency to 3.8.8
- Adjust MemoryUsage chart code for updated XChart API

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_689625d3e9e88320ab9683ec3e395926