### PR TITLE
Enable Xlint and fix warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,10 @@ java {
     targetCompatibility = JavaVersion.VERSION_21
 }
 
+compileJava {
+    options.compilerArgs << '-Xlint'
+}
+
 application {
     mainClass = 'JavaSystemMonitor.Main'
 }

--- a/src/main/java/JavaSystemMonitor/GUI/CPU_Usage.java
+++ b/src/main/java/JavaSystemMonitor/GUI/CPU_Usage.java
@@ -12,10 +12,13 @@ import org.knowm.xchart.XChartPanel;
 public class CPU_Usage extends javax.swing.JPanel
 {
 
+    private static final long serialVersionUID = 1L;
+
     private static final String CPU_USAGE_TITLE = "CPU Usage";
 
-    private DialChart dial;
+    private transient DialChart dial;
 
+    @SuppressWarnings("this-escape")
     public CPU_Usage()
     {
         initComponents();
@@ -42,7 +45,7 @@ public class CPU_Usage extends javax.swing.JPanel
 
         setLayout(new BorderLayout());
 
-        final XChartPanel chartPanel = new XChartPanel(dial);
+        final XChartPanel<DialChart> chartPanel = new XChartPanel<>(dial);
 
         add(chartPanel, BorderLayout.CENTER);
 
@@ -53,7 +56,7 @@ public class CPU_Usage extends javax.swing.JPanel
         final OperatingSystemMXBean mbean
                 = (com.sun.management.OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
 
-        final double CPU_Load = Math.min(1.0, Math.max(0.0, mbean.getSystemCpuLoad()));
+        final double CPU_Load = Math.min(1.0, Math.max(0.0, mbean.getCpuLoad()));
 
         dial.removeSeries(CPU_USAGE_TITLE);
         dial.addSeries(CPU_USAGE_TITLE, CPU_Load, CPU_USAGE_TITLE);
@@ -61,7 +64,7 @@ public class CPU_Usage extends javax.swing.JPanel
         repaint();
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "this-escape"})
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
 

--- a/src/main/java/JavaSystemMonitor/GUI/Disk/DiskEntry.java
+++ b/src/main/java/JavaSystemMonitor/GUI/Disk/DiskEntry.java
@@ -9,6 +9,9 @@ import java.util.logging.Logger;
 public class DiskEntry extends javax.swing.JPanel
 {
 
+    private static final long serialVersionUID = 1L;
+
+    @SuppressWarnings("this-escape")
     public DiskEntry(FileStore store)
     {
         initComponents();
@@ -40,7 +43,7 @@ public class DiskEntry extends javax.swing.JPanel
 
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "this-escape"})
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents()
     {

--- a/src/main/java/JavaSystemMonitor/GUI/Disk/DiskUsage.java
+++ b/src/main/java/JavaSystemMonitor/GUI/Disk/DiskUsage.java
@@ -15,6 +15,9 @@ import javax.swing.BoxLayout;
 public class DiskUsage extends javax.swing.JPanel
 {
 
+    private static final long serialVersionUID = 1L;
+
+    @SuppressWarnings("this-escape")
     public DiskUsage()
     {
         initComponents();
@@ -54,7 +57,7 @@ public class DiskUsage extends javax.swing.JPanel
         }
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "this-escape"})
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents()
     {

--- a/src/main/java/JavaSystemMonitor/GUI/Main_GUI.java
+++ b/src/main/java/JavaSystemMonitor/GUI/Main_GUI.java
@@ -3,13 +3,16 @@ package JavaSystemMonitor.GUI;
 public class Main_GUI extends javax.swing.JFrame
 {
 
+    private static final long serialVersionUID = 1L;
+
+    @SuppressWarnings("this-escape")
     public Main_GUI()
     {
         initComponents();
 
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "this-escape"})
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents()
     {

--- a/src/main/java/JavaSystemMonitor/GUI/MemoryUsage.java
+++ b/src/main/java/JavaSystemMonitor/GUI/MemoryUsage.java
@@ -14,12 +14,15 @@ import org.knowm.xchart.style.PieStyler;
 public class MemoryUsage extends javax.swing.JPanel
 {
 
+    private static final long serialVersionUID = 1L;
+
     private static final String FREE_MEMORY = "Free Memory";
 
     private static final String USED_MEMORY = "Used Memory";
 
-    private PieChart memoryPieChart;
+    private transient PieChart memoryPieChart;
 
+    @SuppressWarnings("this-escape")
     public MemoryUsage()
     {
         initComponents();
@@ -59,7 +62,7 @@ public class MemoryUsage extends javax.swing.JPanel
         memoryPieChart.addSeries(FREE_MEMORY, 0);
         memoryPieChart.addSeries(USED_MEMORY, 0);
 
-        final XChartPanel chartPanel = new XChartPanel(memoryPieChart);
+        final XChartPanel<PieChart> chartPanel = new XChartPanel<>(memoryPieChart);
 
         add(chartPanel, BorderLayout.CENTER);
 
@@ -72,9 +75,9 @@ public class MemoryUsage extends javax.swing.JPanel
         final OperatingSystemMXBean mbean
                 = (com.sun.management.OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
 
-        final double totalMemory = mbean.getTotalPhysicalMemorySize() / Constants.BYTES_TO_GIGABYTES;
+        final double totalMemory = mbean.getTotalMemorySize() / Constants.BYTES_TO_GIGABYTES;
 
-        final double freeMemory = mbean.getFreePhysicalMemorySize() / Constants.BYTES_TO_GIGABYTES;
+        final double freeMemory = mbean.getFreeMemorySize() / Constants.BYTES_TO_GIGABYTES;
 
         final double usedMemory = totalMemory - freeMemory;
 
@@ -85,7 +88,7 @@ public class MemoryUsage extends javax.swing.JPanel
         updateUI();
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "this-escape"})
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
 


### PR DESCRIPTION
## Summary
- compile Java sources with Xlint enabled
- fix raw types, deprecated API usage, and serialization issues
- suppress unavoidable Swing initialization warnings

## Testing
- `gradle clean build`


------
https://chatgpt.com/codex/tasks/task_e_68962b67629c8320918b5f2924cea4f1