### PR TITLE
Remove deprecated file mode API usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'java'
     id 'application'
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
 group = 'com.mycompany'
@@ -24,9 +23,22 @@ dependencies {
     implementation 'org.knowm.xchart:xchart:3.8.8'
 }
 
-shadowJar {
+tasks.register('shadowJar', Jar) {
     archiveClassifier.set('all')
-    mergeServiceFiles()
+    from sourceSets.main.output
+    dependsOn configurations.runtimeClasspath
+    from {
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+    manifest {
+        attributes 'Main-Class': application.mainClass
+    }
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+// Ensure the shadow JAR is built when invoking the standard 'build' task
+tasks.named('build') {
+    dependsOn tasks.named('shadowJar')
 }
 
 jar {


### PR DESCRIPTION
## Summary
- Replace Shadow plugin with custom `shadowJar` task to avoid deprecated file permission APIs
- Hook custom `shadowJar` into standard `build` lifecycle

## Testing
- `gradle build --warning-mode all`


------
https://chatgpt.com/codex/tasks/task_e_68962b299370832082ad6e6e046f40ee