### PR TITLE
Display memory usage in MB/GB

### DIFF
--- a/src/main/java/JavaSystemMonitor/Constants.java
+++ b/src/main/java/JavaSystemMonitor/Constants.java
@@ -5,6 +5,8 @@ public class Constants
 
     public static final int UPDATE_RATE_MS = 1000;
 
+    public static final long BYTES_TO_MEGABYTES = 1024 * 1024;
+
     public static final long BYTES_TO_GIGABYTES = 1024 * 1024 * 1024;
 
     public static final int DEFAULT_WIDTH = 500;

--- a/src/main/java/JavaSystemMonitor/GUI/MemoryUsage.java
+++ b/src/main/java/JavaSystemMonitor/GUI/MemoryUsage.java
@@ -40,7 +40,7 @@ public class MemoryUsage extends javax.swing.JPanel
 
         memoryPieChart = new PieChart(width, height);
 
-        memoryPieChart.getStyler().setLabelType(PieStyler.LabelType.Percentage);
+        memoryPieChart.getStyler().setLabelType(PieStyler.LabelType.Name);
 
         final Color[] colors =
         {
@@ -65,17 +65,34 @@ public class MemoryUsage extends javax.swing.JPanel
         final OperatingSystemMXBean mbean
                 = (com.sun.management.OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
 
-        final double totalMemory = mbean.getTotalMemorySize() / Constants.BYTES_TO_GIGABYTES;
+        final long totalMemory = mbean.getTotalMemorySize();
 
-        final double freeMemory = mbean.getFreeMemorySize() / Constants.BYTES_TO_GIGABYTES;
+        final long freeMemory = mbean.getFreeMemorySize();
 
-        final double usedMemory = totalMemory - freeMemory;
+        final long usedMemory = totalMemory - freeMemory;
 
         memoryPieChart.updatePieSeries(USED_MEMORY, usedMemory);
         memoryPieChart.updatePieSeries(FREE_MEMORY, freeMemory);
 
+        memoryPieChart.getSeriesMap().get(USED_MEMORY).setLabel(
+                String.format("%s: %s", USED_MEMORY, formatMemory(usedMemory)));
+        memoryPieChart.getSeriesMap().get(FREE_MEMORY).setLabel(
+                String.format("%s: %s", FREE_MEMORY, formatMemory(freeMemory)));
+
         revalidate();
         repaint();
+    }
+
+    private String formatMemory(long bytes)
+    {
+        if (bytes >= Constants.BYTES_TO_GIGABYTES)
+        {
+            return String.format("%.2f GB", bytes / (double) Constants.BYTES_TO_GIGABYTES);
+        }
+        else
+        {
+            return String.format("%.2f MB", bytes / (double) Constants.BYTES_TO_MEGABYTES);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Show memory pie chart labels with megabyte or gigabyte values instead of percentages
- Add conversion constant for megabytes

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68963d38860883208f6282279169af02